### PR TITLE
Check error code instead of errno

### DIFF
--- a/bin/swig.js
+++ b/bin/swig.js
@@ -93,7 +93,7 @@ if (argv.o !== 'stdout') {
   try {
     fs.mkdirSync(argv.o);
   } catch (e) {
-    if (e.errno !== 47) {
+    if (e.code !== 'EEXIST') {
       throw e;
     }
   }

--- a/tests/bin/bin.test.js
+++ b/tests/bin/bin.test.js
@@ -179,3 +179,15 @@ describe('bin/swig custom options', function () {
     });
   });
 });
+
+describe('bin/swig output options', function () {
+  it('change output to dir that already exists', function (done) {
+    var p = fixPath(casedir + '/extends_1.test.html');
+    rimraf.sync(tmp);
+    fs.mkdirSync(tmp);
+    runBin('compile ' + p + ' -o ' + tmp, function (err, stdout, stderr) {
+      expect(err).to.be(null);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
My machine returns EEXIST as errno -17. Without this
patch, the swig executable would fail when attempting to output to a
directory that already existed. Checking against the error code EEXIST
solves this issue. This technique also feels more readable.

OS X version 10.10.3
node version 5.1.0